### PR TITLE
Prevent zoom and selection

### DIFF
--- a/www/css/index.css
+++ b/www/css/index.css
@@ -472,3 +472,14 @@ a.projectDirLink:hover {
     height: 24px;
     font-size: 16px;
 }
+
+/*
+    prevent selection on supposed non-selectable things
+*/
+:not(input):not(textarea),
+:not(input):not(textarea)::after,
+:not(input):not(textarea)::before {
+    -webkit-user-select: none;
+    user-select: none;
+    cursor: default;
+}

--- a/www/index.html
+++ b/www/index.html
@@ -7,6 +7,8 @@
             @font-face{font-family:"Source Sans";src:url(../font/SourceSansPro-Semibold.otf);font-weight:600}
         </style>
 
+        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
+
         <link rel="stylesheet" type="text/css" href="css/index.css">
         <link rel='stylesheet' type='text/css' href='css/animate.css'>
         <link rel="stylesheet" type="text/css" href="css/topcoat-desktop-light-custom.min.css">

--- a/www/index.js
+++ b/www/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var app = require('app');  // Module to control application life.
+
 var BrowserWindow = require('browser-window');  // Module to create native browser window.
 
 // Report crashes to our server.
@@ -21,6 +22,7 @@ app.on('window-all-closed', function() {
 // This method will be called when Electron has done everything
 // initialization and ready for creating browser windows.
 app.on('ready', function() {
+    app.commandLine.appendSwitch('--enable-viewport-meta', 'true');
     // Create the browser window.
     if (process.platform != 'win32') {
         mainWindow = new BrowserWindow({width: 450, height: 622, resizable: false, title: 'PhoneGap', center: true});


### PR DESCRIPTION
Zoom is prevented by setting properties in the webview, which is required for the viewport meta tag to work in html.
Selection is prevented via css.
This closes #639.