### PR TITLE
[#717] PGD served app never fires 'deviceready' event on iOS 10

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -14,7 +14,7 @@
       "request" : "2.65.0"
   },
   "devDependencies" : {
-      "phonegap" : "6.3.1"
+      "phonegap" : "6.3.4"
   },
   "licenses": [{
       "type":"ALv2",


### PR DESCRIPTION
Updating to use connect-phonegap 0.23.2, included in Phonegap 6.3.4